### PR TITLE
Add storage-java to community client libraries.

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -77,7 +77,7 @@ Unnofficial Supabase libraries, examples, and repositories by the community for 
     <td>-</td>
     <td><a href="https://github.com/supabase-community/gotrue-java" target="_blank" rel="noopener noreferrer">gotrue-java</a></td>
     <td>-</td>
-    <td>-</td>
+    <td><a href="https://github.com/supabase-community/storage-java" target="_blank" rel="noopener noreferrer">storage-java</a></td>
     <td>-</td>
   </tr>
   <tr>


### PR DESCRIPTION
I've spent the past 2 days working on a storage api client in Java. https://github.com/magnushjensen/storage-java 
I would say it's at a usable state for a community repo. 
It has basically 100% test coverage, (inspired from storage-js). 
It has build&test workflows for push and PR's, alongside publishing javadoc to `javadoc` branch. It contains an example.
It also has dependabot enabled.
It just needs some more JavaDocs, which I'm currently working on atm.

This is my request to hopefully contribute and possibly transfer the repository to you guys! :D