### PR TITLE
chore: rename gotrue-go to auth-go

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -93,7 +93,7 @@ Unnofficial Supabase libraries, examples, and repositories by the community for 
     <td>Go</td>
     <td>-</td>
     <td><a href="https://github.com/supabase-community/postgrest-go" target="_blank" rel="noopener noreferrer">postgrest-go</a></td>
-    <td><a href="https://github.com/supabase-community/gotrue-go" target="_blank" rel="noopener noreferrer">gotrue-go</a></td>
+    <td><a href="https://github.com/supabase-community/auth-go" target="_blank" rel="noopener noreferrer">auth-go</a></td>
     <td>-</td>
     <td><a href="https://github.com/supabase-community/storage-go" target="_blank" rel="noopener noreferrer">storage-go</a></td>
     <td><a href="https://github.com/supabase-community/functions-go" target="_blank" rel="noopener noreferrer">functions-go</a</td>


### PR DESCRIPTION
## What kind of change does this PR introduce?

`gotrue-go` has been deprecated in favor of `auth-go`.