### PR TITLE
fix: remove reference to auth helpers in README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -154,15 +154,6 @@ Unnofficial Supabase libraries, examples, and repositories by the community for 
   </tr>
 </table>
 
-## Supabase Auth Helpers
-
-A collection of framework specific Auth utilities for working with Supabase.
-
-- [Next.js](https://github.com/supabase/auth-helpers/blob/main/packages/nextjs/README.md)
-- [Nuxt - via @nuxtjs/supabase](https://supabase.nuxtjs.org/)
-- [SvelteKit](https://github.com/supabase/auth-helpers/blob/main/packages/sveltekit/README.md)
-- [Remix](https://github.com/supabase/auth-helpers/tree/main/packages/remix)
-
 ## Self-Hosting
 
 - [supabase-kubernetes](https://github.com/supabase-community/supabase-kubernetes)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removes reference to Auth-Helpers as:

1. They are deprecated
2. They are no longer in Supabase-community