### PR TITLE
docs(community): include Supabase testing frameworks and helpers in R…

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -186,3 +186,9 @@ Unnofficial Supabase libraries, examples, and repositories by the community for 
 - Vue + Nuxt
   - [nuxt-supabase](https://github.com/supabase-community/nuxt-supabase)
   - [vue-supabase](https://github.com/supabase-community/vue-supabase)
+
+## Testing
+
+- [supabase-test-helpers](https://database.dev/basejump/supabase_test_helpers)
+- [supabase-test](https://www.npmjs.com/package/supabase-test)
+- [supawright](https://github.com/isaacharrisholt/supawright)


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update — adds curated Supabase testing frameworks and helpers to the community README.

## What is the current behavior?

The community README does not currently include a dedicated section or references for Supabase-related testing tools.

## What is the new behavior?

The README now includes a list of Supabase testing resources, making it easier for developers to find, compare, and adopt testing tools when working with Supabase projects.